### PR TITLE
Added a columnTransform func to transform column names

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,7 +71,12 @@ The options are also passed to the underlying transform stream, so you can pass 
   objectMode: false,
 
   // if set to true, uses first row as keys -> [ { column1: value1, column2: value2 }, ...]
-  columns: false
+  columns: false,
+  
+  // each csv column name is optionally mapped to this so its value can be transformed
+  columnTransform: function(name) {
+    return name
+  }
 }
 ```
 

--- a/csv-streamify.js
+++ b/csv-streamify.js
@@ -16,7 +16,8 @@ module.exports = function (opts, cb) {
   opts.empty = opts.hasOwnProperty('empty') ? opts.empty : ''
   opts.objectMode = opts.objectMode || false
   opts.hasColumns = opts.columns || false
-
+  opts.columnTransform = opts.columnTransform || function(l) { return l }
+  
   // state
   var state = {
     body: [],
@@ -41,7 +42,7 @@ function createParser (opts, state) {
 
     if (opts.hasColumns) {
       if (state.lineNo === 0) {
-        state._columns = state._line
+        state._columns = state._line.map(opts.columnTransform)
         state.lineNo += 1
         reset()
         return

--- a/csv-streamify.js
+++ b/csv-streamify.js
@@ -16,8 +16,8 @@ module.exports = function (opts, cb) {
   opts.empty = opts.hasOwnProperty('empty') ? opts.empty : ''
   opts.objectMode = opts.objectMode || false
   opts.hasColumns = opts.columns || false
-  opts.columnTransform = opts.columnTransform || function(l) { return l }
-  
+  opts.columnTransform = opts.columnTransform || function (l) { return l }
+
   // state
   var state = {
     body: [],


### PR DESCRIPTION
It's not uncommon for a CSV file to have strange or badly formatted column names. This PR adds a new transform function option (mapped to each column name) so column names can be overridden as needed. The default simply returns the existing value so nothing changes. 

Usage might be something like this:

```
let parser = csv({
  columnTransform: function(name) {
    switch (name) {
      case 'some Weird Name':
        return 'new_name'
      default:
        return name
    }
  },
  columns: true
})
```